### PR TITLE
fix: starting and size for FLASH

### DIFF
--- a/boot/src/gcc/STM32G431RBTX_FLASH.ld
+++ b/boot/src/gcc/STM32G431RBTX_FLASH.ld
@@ -64,7 +64,7 @@ MEMORY
 {
   CCMSRAM    (xrw)    : ORIGIN = 0x10000000,   LENGTH = 10K
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 32K
-  ROM    (rx)    : ORIGIN = 0x08000000,   LENGTH = 128K
+  ROM    (rx)    : ORIGIN = 0x08000000,   LENGTH = 28K
 }
 
 /* Sections */
@@ -104,12 +104,12 @@ SECTIONS
     . = ALIGN(4);
   } >ROM
 
-  .ARM.extab   : { 
+  .ARM.extab   : {
     . = ALIGN(4);
     *(.ARM.extab* .gnu.linkonce.armextab.*)
     . = ALIGN(4);
   } >ROM
-  
+
   .ARM : {
     . = ALIGN(4);
     __exidx_start = .;
@@ -126,7 +126,7 @@ SECTIONS
     PROVIDE_HIDDEN (__preinit_array_end = .);
     . = ALIGN(4);
   } >ROM
-  
+
   .init_array :
   {
     . = ALIGN(4);
@@ -136,7 +136,7 @@ SECTIONS
     PROVIDE_HIDDEN (__init_array_end = .);
     . = ALIGN(4);
   } >ROM
-  
+
   .fini_array :
   {
     . = ALIGN(4);
@@ -151,7 +151,7 @@ SECTIONS
   _sidata = LOADADDR(.data);
 
   /* Initialized data sections into "RAM" Ram type memory */
-  .data : 
+  .data :
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
@@ -160,7 +160,7 @@ SECTIONS
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-    
+
   } >RAM AT> ROM
 
   /* Uninitialized data section into "RAM" Ram type memory */

--- a/boot/src/main.c
+++ b/boot/src/main.c
@@ -47,8 +47,8 @@ int main(void)
 		Error_Handler();
 	}
 
-	BOOT_LOG_INF("Bootloader chainload address offset: 0x%x", (int)rsp.br_image_off);
 	BOOT_LOG_INF("Jumping to the first image slot");
+	BOOT_LOG_INF("Bootloader chainload address offset: 0x%x", (int)rsp.br_image_off);
 
 	// De-initialize the system (clocks, peripherals, etc.)
 	// No more logging or blinking LEDs after this point

--- a/flash.sh
+++ b/flash.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -eu -o pipefail
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <project_name>"
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <bin> <address>"
     exit 1
 fi
 
-test -f "$1/out/$1.bin" || {
-    echo "$1/out/$1.bin does not exist"
+test -f "$1" || {
+    echo "$1 does not exist"
     exit 1
 }
 
-st-flash write $1/out/$1.bin 0x08000000
+st-flash write $1 $2
 st-flash reset

--- a/hello1/src/gcc/STM32G431RBTX_FLASH.ld
+++ b/hello1/src/gcc/STM32G431RBTX_FLASH.ld
@@ -64,7 +64,7 @@ MEMORY
 {
   CCMSRAM    (xrw)    : ORIGIN = 0x10000000,   LENGTH = 10K
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 32K
-  ROM    (rx)    : ORIGIN = 0x08000000,   LENGTH = 128K
+  ROM    (rx)    : ORIGIN = 0x08007000,   LENGTH = 50K
 }
 
 /* Sections */
@@ -104,12 +104,12 @@ SECTIONS
     . = ALIGN(4);
   } >ROM
 
-  .ARM.extab   : { 
+  .ARM.extab   : {
     . = ALIGN(4);
     *(.ARM.extab* .gnu.linkonce.armextab.*)
     . = ALIGN(4);
   } >ROM
-  
+
   .ARM : {
     . = ALIGN(4);
     __exidx_start = .;
@@ -126,7 +126,7 @@ SECTIONS
     PROVIDE_HIDDEN (__preinit_array_end = .);
     . = ALIGN(4);
   } >ROM
-  
+
   .init_array :
   {
     . = ALIGN(4);
@@ -136,7 +136,7 @@ SECTIONS
     PROVIDE_HIDDEN (__init_array_end = .);
     . = ALIGN(4);
   } >ROM
-  
+
   .fini_array :
   {
     . = ALIGN(4);
@@ -151,7 +151,7 @@ SECTIONS
   _sidata = LOADADDR(.data);
 
   /* Initialized data sections into "RAM" Ram type memory */
-  .data : 
+  .data :
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
@@ -160,7 +160,7 @@ SECTIONS
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-    
+
   } >RAM AT> ROM
 
   /* Uninitialized data section into "RAM" Ram type memory */

--- a/hello2/src/gcc/STM32G431RBTX_FLASH.ld
+++ b/hello2/src/gcc/STM32G431RBTX_FLASH.ld
@@ -64,7 +64,7 @@ MEMORY
 {
   CCMSRAM    (xrw)    : ORIGIN = 0x10000000,   LENGTH = 10K
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 32K
-  ROM    (rx)    : ORIGIN = 0x08000000,   LENGTH = 128K
+  ROM    (rx)    : ORIGIN = 0x08013800,   LENGTH = 50K
 }
 
 /* Sections */
@@ -104,12 +104,12 @@ SECTIONS
     . = ALIGN(4);
   } >ROM
 
-  .ARM.extab   : { 
+  .ARM.extab   : {
     . = ALIGN(4);
     *(.ARM.extab* .gnu.linkonce.armextab.*)
     . = ALIGN(4);
   } >ROM
-  
+
   .ARM : {
     . = ALIGN(4);
     __exidx_start = .;
@@ -126,7 +126,7 @@ SECTIONS
     PROVIDE_HIDDEN (__preinit_array_end = .);
     . = ALIGN(4);
   } >ROM
-  
+
   .init_array :
   {
     . = ALIGN(4);
@@ -136,7 +136,7 @@ SECTIONS
     PROVIDE_HIDDEN (__init_array_end = .);
     . = ALIGN(4);
   } >ROM
-  
+
   .fini_array :
   {
     . = ALIGN(4);
@@ -151,7 +151,7 @@ SECTIONS
   _sidata = LOADADDR(.data);
 
   /* Initialized data sections into "RAM" Ram type memory */
-  .data : 
+  .data :
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
@@ -160,7 +160,7 @@ SECTIONS
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-    
+
   } >RAM AT> ROM
 
   /* Uninitialized data section into "RAM" Ram type memory */

--- a/sign_img.sh
+++ b/sign_img.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu -o pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <project_name>"
+    exit 1
+fi
+
+test -f "$1/out/$1.bin" || {
+    echo "$1/out/$1.bin does not exist"
+    exit 1
+}
+
+python3 lib/mcuboot/scripts/imgtool.py sign \
+    --header-size 0x200 \
+    --align 4 \
+    --slot-size 0xC800 \
+    --version 1.0.0 \
+    --pad-header \
+    $1/out/$1.bin $1/out/signed.bin


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted memory layout for the STM32G431RBTX device across multiple projects, optimizing ROM region sizes and origins.
- **Chores**
	- Updated `flash.sh` and `sign_img.sh` scripts to enhance usability and functionality, including better parameter handling and streamlined binary signing process.
- **Style**
	- Improved code formatting in various files, making the codebase cleaner and more consistent.
- **Bug Fixes**
	- Fixed the order of log messages in the bootloader to accurately reflect the operational sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->